### PR TITLE
Fix missing byte in some reads

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -111,15 +111,15 @@ else
     exit
 fi
 
-yes 0123 | head -n 10000 > ${DIR}/big.txt
-if [[ $(cat ${DIR}/big.txt | wc) = "$(yes 0123 | head -n 10000 | wc)" ]]; then
+yes 0123456 | head -n 512 > ${DIR}/big.txt
+if [[ $(cat ${DIR}/big.txt | wc) = "$(yes 0123456 | head -n 512 | wc)" ]]; then
     echo -e "$GREEN OK 4 $NC"
 else
     echo -e "$RED FAILED on big.txt $NC"
     export TEST_EXIT_STATUS=1
     exit
 fi
-if [[ $(cat ${DIR2}/big.txt | wc) = "$(yes 0123 | head -n 10000 | wc)" ]]; then
+if [[ $(cat ${DIR2}/big.txt | wc) = "$(yes 0123456 | head -n 512 | wc)" ]]; then
     echo -e "$GREEN OK 4 replica $NC"
 else
     echo -e "$RED FAILED on big.txt replica $NC"

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -51,7 +51,6 @@ echo "generic/434" >> xfs_excludes.txt
 echo "generic/478" >> xfs_excludes.txt
 
 # TODO: Broken. Dunno why
-echo "generic/001" >> xfs_excludes.txt
 echo "generic/013" >> xfs_excludes.txt
 echo "generic/035" >> xfs_excludes.txt
 echo "generic/075" >> xfs_excludes.txt


### PR DESCRIPTION
Off-by-one error lead to missing byte when reading a multiple
of 4096 (probably smaller multiples too)