### PR TITLE
Fix possibly truncated reads

### DIFF
--- a/flatbuffers/messages.fbs
+++ b/flatbuffers/messages.fbs
@@ -74,8 +74,14 @@ table RemoveXattrRequest {
   key: string (required);
 }
 
+struct CommitId {
+  term: ulong;
+  index: ulong;
+}
+
 // Reads only the blocks of data on this node
 table ReadRawRequest {
+  required_commit: CommitId (required);
   inode: ulong;
   offset: ulong;
   read_size: uint;

--- a/pjdfs.sh
+++ b/pjdfs.sh
@@ -26,7 +26,7 @@ cargo run -- --port 3304 --data-dir $DATA_DIR5 --peers 127.0.0.1:3300,127.0.0.1:
 cargo run -- --port 3305 --data-dir $DATA_DIR6 --peers 127.0.0.1:3300,127.0.0.1:3301,127.0.0.1:3302,127.0.0.1:3303,127.0.0.1:3304 > /code/logs/daemon5.log 2>&1 &
 
 # Wait for leader to be elected
-until cargo run --release -- --server-ip-port 127.0.0.1:3300 --get-leader; do
+until cargo run -- --server-ip-port 127.0.0.1:3300 --get-leader; do
     sleep 0.1
 done
 

--- a/src/client/peer_client.rs
+++ b/src/client/peer_client.rs
@@ -40,6 +40,7 @@ pub trait PeerClient {
         inode: u64,
         offset: u64,
         size: u32,
+        required_commit: CommitId,
     ) -> BoxFuture<'static, Result<Vec<u8>, std::io::Error>>;
 }
 
@@ -228,12 +229,14 @@ impl PeerClient for TcpPeerClient {
         inode: u64,
         offset: u64,
         size: u32,
+        required_commit: CommitId,
     ) -> BoxFuture<'static, Result<Vec<u8>, std::io::Error>> {
         let mut builder = FlatBufferBuilder::new();
         let mut request_builder = ReadRawRequestBuilder::new(&mut builder);
         request_builder.add_offset(offset);
         request_builder.add_read_size(size);
         request_builder.add_inode(inode);
+        request_builder.add_required_commit(&required_commit);
         let finish_offset = request_builder.finish().as_union_value();
         finalize_request(&mut builder, RequestType::ReadRawRequest, finish_offset);
 

--- a/src/storage/local/file_storage.rs
+++ b/src/storage/local/file_storage.rs
@@ -229,10 +229,13 @@ impl FileStorage {
         inode: u64,
         offset: u64,
         read_size: u32,
+        required_commit: CommitId,
         builder: FlatBufferBuilder<'static>,
     ) -> impl Future<Output = Result<FlatBufferWithResponse<'static>, ErrorCode>> + '_ {
         // No access check is needed, since we rely on the client to do it
-        let read_result = self.data_storage.read(inode, offset, read_size);
+        let read_result = self
+            .data_storage
+            .read(inode, offset, read_size, required_commit);
         read_result.map(move |response| Ok(to_fast_read_response(builder, response)))
     }
 

--- a/src/storage/raft_node.rs
+++ b/src/storage/raft_node.rs
@@ -185,6 +185,7 @@ impl RaftNode {
         unreachable!();
     }
 
+    // TODO: we need to also get the term from the leader. The index alone isn't meaningful
     pub fn get_latest_commit_from_leader(&self) -> impl Future<Output = Result<u64, ErrorCode>> {
         let raft_node = self.raft_node.lock().unwrap();
 

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -12,12 +12,20 @@ export RUST_BACKTRACE=1
 
 DATA_DIR=$(mktemp --directory)
 DATA_DIR2=$(mktemp --directory)
+DATA_DIR3=$(mktemp --directory)
+DATA_DIR4=$(mktemp --directory)
+DATA_DIR5=$(mktemp --directory)
+DATA_DIR6=$(mktemp --directory)
 cargo build --release
 # Copy into PATH, so that xfstests can find the binary
 cp target/release/fleetfs /bin/fleetfs
 
-cargo run --release -- --port 3300 --data-dir $DATA_DIR --peers 127.0.0.1:3301 > /code/logs/daemon0.log 2>&1 &
-cargo run --release -- --port 3301 --data-dir $DATA_DIR2 --peers 127.0.0.1:3300 > /code/logs/daemon1.log 2>&1 &
+cargo run --release -- --port 3300 --data-dir $DATA_DIR  --redundancy-level 1 --peers 127.0.0.1:3301,127.0.0.1:3302,127.0.0.1:3303,127.0.0.1:3304,127.0.0.1:3305 > /code/logs/daemon0.log 2>&1 &
+cargo run --release -- --port 3301 --data-dir $DATA_DIR2 --redundancy-level 1 --peers 127.0.0.1:3300,127.0.0.1:3302,127.0.0.1:3303,127.0.0.1:3304,127.0.0.1:3305 > /code/logs/daemon1.log 2>&1 &
+cargo run --release -- --port 3302 --data-dir $DATA_DIR3 --redundancy-level 1 --peers 127.0.0.1:3300,127.0.0.1:3301,127.0.0.1:3303,127.0.0.1:3304,127.0.0.1:3305 > /code/logs/daemon2.log 2>&1 &
+cargo run --release -- --port 3303 --data-dir $DATA_DIR4 --redundancy-level 1 --peers 127.0.0.1:3300,127.0.0.1:3301,127.0.0.1:3302,127.0.0.1:3304,127.0.0.1:3305 > /code/logs/daemon3.log 2>&1 &
+cargo run --release -- --port 3304 --data-dir $DATA_DIR5 --redundancy-level 1 --peers 127.0.0.1:3300,127.0.0.1:3301,127.0.0.1:3302,127.0.0.1:3303,127.0.0.1:3305 > /code/logs/daemon4.log 2>&1 &
+cargo run --release -- --port 3305 --data-dir $DATA_DIR6 --redundancy-level 1 --peers 127.0.0.1:3300,127.0.0.1:3301,127.0.0.1:3302,127.0.0.1:3303,127.0.0.1:3304 > /code/logs/daemon5.log 2>&1 &
 
 SCRATCH_DIR=$(mktemp --directory)
 SCRATCH_DIR2=$(mktemp --directory)
@@ -25,9 +33,12 @@ cargo run --release -- --port 3400 --data-dir $SCRATCH_DIR --peers 127.0.0.1:340
 cargo run --release -- --port 3401 --data-dir $SCRATCH_DIR2 --peers 127.0.0.1:3400 > /code/logs/scratch1.log 2>&1 &
 
 # Wait for leaders to be elected
-sleep 0.5
-cargo run --release -- --server-ip-port 127.0.0.1:3300 --get-leader
-cargo run --release -- --server-ip-port 127.0.0.1:3400 --get-leader
+until cargo run --release -- --server-ip-port 127.0.0.1:3300 --get-leader; do
+    sleep 0.1
+done
+until cargo run --release -- --server-ip-port 127.0.0.1:3400 --get-leader; do
+    sleep 0.1
+done
 
 sleep 0.5
 


### PR DESCRIPTION
The read_raw() internal API didn't sync with the leader, and therefore
could be missing an arbitrary number of commits in large clusters.

Also run xfstests on more servers