### PR TITLE
Fix: Prevent file descriptor leak in DataStorage::fsync

### DIFF
--- a/src/storage/local/data_storage.rs
+++ b/src/storage/local/data_storage.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::os::unix::fs::FileExt;
-use std::os::unix::io::IntoRawFd;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 use walkdir::WalkDir;
@@ -286,9 +285,7 @@ impl<T: PeerClient> DataStorage<T> {
         info!("Fsync'ing {}", inode);
         let local_path = self.to_local_path(&inode.to_string());
         let file = File::open(local_path).map_err(into_error_code)?;
-        unsafe {
-            libc::fsync(file.into_raw_fd());
-        }
+        file.sync_all().map_err(into_error_code)?;
         Ok(())
     }
 


### PR DESCRIPTION
The `DataStorage::fsync` method was previously using `file.into_raw_fd()` to get a raw file descriptor for `libc::fsync`. However, it did not subsequently call `libc::close()` on this descriptor. Since `into_raw_fd()` consumes the `File` object, its `Drop` handler (which would close the FD) was also bypassed. This resulted in a file descriptor leak on every call to `fsync`.

This commit fixes the leak by replacing the manual `libc::fsync` call with the idiomatic Rust method `file.sync_all()`. This method ensures that the file descriptor is properly managed by the `File` object's RAII behavior, automatically closing it when the `File` object goes out of scope. The existing error handling `map_err(into_error_code)` is compatible with `sync_all()`.